### PR TITLE
Check if uninstaller.sh exist

### DIFF
--- a/Casks/netbird-ui.rb
+++ b/Casks/netbird-ui.rb
@@ -1,6 +1,3 @@
-
-
-
 # Netbird's UI Client Cask Formula
 cask "netbird-ui" do
   version "0.64.5"
@@ -29,8 +26,12 @@ cask "netbird-ui" do
   end
 
   uninstall_preflight do
-    system_command "#{appdir}/Netbird UI.app/uninstaller.sh",
-                   sudo: false
+    uninstaller = "#{appdir}/Netbird UI.app/uninstaller.sh"
+
+    if File.exist?(uninstaller)
+      system_command uninstaller,
+                     sudo: false
+    end
   end
 
   name "Netbird UI"


### PR DESCRIPTION
Sometimes (I don't even know why, probably after not upgrading for a long time?), `uninstaller.sh` does not exist. This completely prevents
1) upgrading
2) uninstalling
via brew. This PR checks if the file exists *first*, so that if it does not exist the user can use brew normally.

Closes https://github.com/netbirdio/netbird/issues/1924