### PR TITLE
Stop and remove daemon on netbird-ui cask uninstall

### DIFF
--- a/Casks/netbird-ui.rb
+++ b/Casks/netbird-ui.rb
@@ -29,8 +29,13 @@ cask "netbird-ui" do
   end
 
   uninstall_preflight do
-    system_command "#{appdir}/Netbird UI.app/uninstaller.sh",
-                   sudo: false
+    system_command "/bin/sh",
+                   args: ["-c", <<~CMD],
+                     launchctl bootout system/netbird 2>/dev/null || \
+                       launchctl unload /Library/LaunchDaemons/netbird.plist 2>/dev/null || true
+                     rm -f /Library/LaunchDaemons/netbird.plist
+                   CMD
+                   sudo: true
   end
 
   name "Netbird UI"


### PR DESCRIPTION
Fixes leftover daemon after `brew uninstall --cask netbird-ui`. Previously the cask invoked the bundled `uninstaller.sh` without sudo, which only printed instructions; the LaunchDaemon plist and running daemon were left behind.

- Run cleanup inline so the cask doesn't depend on the script bundled inside the `.app`
- Bootout the `netbird` system daemon and remove `/Library/LaunchDaemons/netbird.plist`
- Run with `sudo: true` so the privileged operations actually go through

Fixes #4. Also resolves netbirdio/netbird#5852, netbirdio/netbird#1924, and netbirdio/netbird#5135.
