### PR TITLE
fix: stop and remove daemon on netbird CLI formula uninstall

### DIFF
--- a/netbird.rb
+++ b/netbird.rb
@@ -51,6 +51,23 @@ class Netbird < Formula
     end
   end
 
+  def uninstall_post
+    system "launchctl", "bootout", "system/netbird"
+    rm_f "/Library/LaunchDaemons/netbird.plist"
+  rescue
+    # ignore errors if launchctl is unavailable or service is already stopped
+  end
+
+  def caveats
+    <<~EOS
+      If you installed the NetBird service via `sudo netbird service install`,
+      stop and uninstall it before upgrading or removing this formula:
+
+        sudo netbird service stop
+        sudo netbird service uninstall
+    EOS
+  end
+
   test do
     system "#{bin}/netbird version"
   end


### PR DESCRIPTION
**Problem**
`brew uninstall netbird` leaves behind the running daemon and `/Library/LaunchDaemons/netbird.plist` because the formula has no cleanup hook.

**Solution**
Add `uninstall_post` to bootout the `netbird` launchd service and remove the plist. Also add `caveats` reminding users to run `netbird service uninstall` before upgrading.

Fixes netbirdio/netbird#5852

**Validation**
`ruby -c netbird.rb`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically stops the NetBird background service and removes its system configuration when uninstalling.

* **Documentation**
  * Added guidance for stopping and uninstalling the NetBird service before upgrading or removing the Homebrew package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->