### PR TITLE
Restart the NetBird service after upgrade if it was running

### DIFF
--- a/netbird.rb
+++ b/netbird.rb
@@ -51,18 +51,25 @@ class Netbird < Formula
     end
   end
 
-  # `brew upgrade` swaps the binary out from under the running daemon:
-  # launchd (or systemd) keeps the old process alive,
-  # so NetBird goes on serving the previous version until something restarts it.
-  # Restart it here, but only when it is already running,
-  # so an upgrade never starts a daemon the user deliberately stopped.
+  # `brew upgrade` swaps the binary out from under the running daemon: launchd
+  # (or systemd) keeps the old process alive, so NetBird goes on serving the
+  # previous version until something restarts it. Restart it here -- but only
+  # when it is already running, so an upgrade never starts a daemon the user
+  # deliberately stopped.
+  #
+  # NOTE: local addition. GoReleaser regenerates this file on every release, so
+  # this block has to live in `brews[].post_install` in netbird's .goreleaser.yaml
+  # to survive: https://github.com/netbirdio/netbird/pull/7394
   def post_install
     return unless daemon_running?
 
     ohai "Restarting the NetBird service"
-    # `sudo -n` first, so a still-cached credential means no prompt at all.
-    return if restart_daemon(sudo_args: ["-n"], err: File::NULL)
-    return if $stdin.tty? && restart_daemon
+    # `sudo -n` only: brew resets the sudo timestamp at startup, so this
+    # succeeds just for NOPASSWD setups -- and an interactive prompt cannot be
+    # offered here, because the post-install sandbox runs this code in a
+    # pseudoterminal, where $stdin.tty? is true even for a headless
+    # `brew upgrade` and a prompt would stall it until sudo times out.
+    return if restart_daemon
 
     opoo <<~EOS
       The NetBird service is still running the previous version. Restart it with:
@@ -73,16 +80,20 @@ class Netbird < Formula
   # The daemon runs as root, so the process table is the only place its state
   # can be read from without asking for a password ("netbird service status"
   # and launchctl both report a root daemon as stopped when asked by a plain
-  # user). The leading slash keeps shell command lines that merely mention
-  # "netbird service run" from matching.
+  # user). The daemon's command line starts with the stable brew-linked binary
+  # path ("netbird service install" records the path `which netbird` resolved
+  # to), so anchoring the pattern to it keeps command lines that merely
+  # mention "netbird service run" from matching.
   def daemon_running?
-    Kernel.system("pgrep", "-f", "/netbird service run", out: File::NULL, err: File::NULL)
+    Kernel.system("pgrep", "-f", "^#{HOMEBREW_PREFIX}/bin/netbird service run",
+                  out: File::NULL, err: File::NULL)
   end
 
-  # Not `Formula#system`: That one sends the child's output to a log file,
-  # which would swallow the sudo password prompt, and raises on a non-zero exit.
-  def restart_daemon(sudo_args: [], **options)
-    Kernel.system("sudo", *sudo_args, "#{opt_bin}/netbird", "service", "restart", **options)
+  # Not `Formula#system`: that one raises on a non-zero exit, and a failed
+  # restart attempt must fall through to the printed instructions instead.
+  def restart_daemon
+    Kernel.system("sudo", "-n", "#{opt_bin}/netbird", "service", "restart",
+                  out: File::NULL, err: File::NULL)
   end
 
   test do

--- a/netbird.rb
+++ b/netbird.rb
@@ -51,6 +51,40 @@ class Netbird < Formula
     end
   end
 
+  # `brew upgrade` swaps the binary out from under the running daemon:
+  # launchd (or systemd) keeps the old process alive,
+  # so NetBird goes on serving the previous version until something restarts it.
+  # Restart it here, but only when it is already running,
+  # so an upgrade never starts a daemon the user deliberately stopped.
+  def post_install
+    return unless daemon_running?
+
+    ohai "Restarting the NetBird service"
+    # `sudo -n` first, so a still-cached credential means no prompt at all.
+    return if restart_daemon(sudo_args: ["-n"], err: File::NULL)
+    return if $stdin.tty? && restart_daemon
+
+    opoo <<~EOS
+      The NetBird service is still running the previous version. Restart it with:
+        sudo netbird service restart
+    EOS
+  end
+
+  # The daemon runs as root, so the process table is the only place its state
+  # can be read from without asking for a password ("netbird service status"
+  # and launchctl both report a root daemon as stopped when asked by a plain
+  # user). The leading slash keeps shell command lines that merely mention
+  # "netbird service run" from matching.
+  def daemon_running?
+    Kernel.system("pgrep", "-f", "/netbird service run", out: File::NULL, err: File::NULL)
+  end
+
+  # Not `Formula#system`: That one sends the child's output to a log file,
+  # which would swallow the sudo password prompt, and raises on a non-zero exit.
+  def restart_daemon(sudo_args: [], **options)
+    Kernel.system("sudo", *sudo_args, "#{opt_bin}/netbird", "service", "restart", **options)
+  end
+
   test do
     system "#{bin}/netbird version"
   end


### PR DESCRIPTION
## What

`brew upgrade netbird` links the new binary, but launchd (macOS) / systemd (Linux) keeps the old daemon process alive, so NetBird silently keeps serving the previous version until something restarts it. (The `netbird-ui` cask's `installer.sh` reinstalls the service on *cask* upgrades, but a formula-only `brew upgrade netbird` leaves the old daemon running.)

This adds a `post_install` hook to `netbird.rb` that restarts the daemon after an upgrade:

- **Only when it was already running** — an upgrade never starts a daemon the user deliberately stopped. Detection reads the process table with a pattern anchored to the brew-linked binary path (`pgrep -f "^#{HOMEBREW_PREFIX}/bin/netbird service run"`), because `netbird service status` and `launchctl` both report a root daemon as *Stopped* when asked by a plain user, and the anchor keeps unrelated command lines from matching.
- Restart is `sudo -n netbird service restart` only. Homebrew resets the sudo timestamp at startup, so this succeeds just for NOPASSWD setups — and an interactive prompt cannot be offered, because the post-install sandbox runs the hook in a pseudoterminal where `$stdin.tty?` is true even for a headless upgrade, so a prompt would stall unattended upgrades until sudo times out.
- In every other case it prints the `sudo netbird service restart` one-liner instead of failing the upgrade.

The legacy `def post_install` is used instead of Homebrew's newer `post_install_steps` DSL because the DSL cannot express the "only when already running" guard — an unconditional restart step would start a stopped daemon.

## Companion PR

`netbird.rb` is generated by GoReleaser and rewritten on every release, so this fix alone lasts until the next version bump. netbirdio/netbird#7394 adds the same block to `.goreleaser.yaml` (`brews[].post_install` + `custom_block`) so future releases regenerate the formula with the hook included. This PR applies the fix to the tap immediately; both reviewed together make it permanent.

## Testing

- `ruby -c` and `brew style` clean (no new offenses; the 5 reported are pre-existing GoReleaser output)
- Formula loads through Homebrew 6.0: `post_install_defined? => true`
- Verified against a live macOS daemon (`/opt/homebrew/bin/netbird service run`, root, KeepAlive): detection returns true; a decoy process merely mentioning "netbird service run" in its arguments does **not** match the anchored pattern
- Full `post_install` exercised: detects the daemon, `sudo -n` fails quietly without NOPASSWD, prints the restart instructions, exits cleanly without failing the upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)
